### PR TITLE
Fixed deprecated relative import

### DIFF
--- a/git_auto_export/tasks.py
+++ b/git_auto_export/tasks.py
@@ -3,7 +3,7 @@ from celery.utils.log import get_task_logger
 
 from opaque_keys.edx.keys import CourseKey
 from xmodule.modulestore.django import modulestore
-from contentstore.git_export_utils import export_to_git, GitExportError
+from cms.djangoapps.contentstore.git_export_utils import export_to_git, GitExportError
 
 
 LOGGER = get_task_logger(__name__)


### PR DESCRIPTION
Migration seems to be failing with the error below:

```
raise DeprecatedEdxPlatformImportError(old_import, new_import)", "import_shims.warn.DeprecatedEdxPlatformImportError: Importing contentstore instead of cms.djangoapps.contentstore is deprecated"], "stdout": "", "stdout_lines": []}
```

This PR should fix that problem.