### PR TITLE
fix: remove deprecated celery task and use shared_task

### DIFF
--- a/git_auto_export/__init__.py
+++ b/git_auto_export/__init__.py
@@ -1,2 +1,2 @@
-__version__ = 0.2
+__version__ = 0.3
 default_app_config = 'git_auto_export.apps.GitAutoExportConfig'

--- a/git_auto_export/tasks.py
+++ b/git_auto_export/tasks.py
@@ -1,4 +1,4 @@
-from celery.task import task
+from celery import shared_task  # pylint: disable=import-error
 from celery.utils.log import get_task_logger
 
 from opaque_keys.edx.keys import CourseKey
@@ -9,7 +9,7 @@ from cms.djangoapps.contentstore.git_export_utils import export_to_git, GitExpor
 LOGGER = get_task_logger(__name__)
 
 
-@task()
+@shared_task
 def async_export_to_git(course_key_string, user=None):
     """
     Exports a course to Git.


### PR DESCRIPTION
## Related ticket:
#4 

## What this PR does?
- Replaces the usage of the deprecated `celery.task`  with `celery.shared_task` after edx upgraded the celery to 5.x.x.

More details can be seen on associated ticket #4 

## How to test?
The change itself was straight forward but setting up the things to test auto-export takes some time. I'm trying to configure it to use locally so that I can test it.