### PR TITLE
docs: Add deprecation message in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 ⛔️ DEPRECATION WARNING
 ======================
 
-This repository is deprecated. Please see `open-edx-plugins <https://github.com/mitodl/open-edx-plugins>`__ for all the future updates and development.
+This repository is deprecated. Please see [open-edx-plugins](https://github.com/mitodl/open-edx-plugins) for all the future updates and development.
+----------------------------------------------------------------------------------------------------------------------------------------------------
 
 
 #### Steps to install on edX platform:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+
+⛔️ DEPRECATION WARNING
+======================
+
+This repository is deprecated. Please see `open-edx-plugins <https://github.com/mitodl/open-edx-plugins>`__ for all the future updates and development.
+
+
 #### Steps to install on edX platform:
 
 - open cms.env and lms.env or private.py and set FEATURES flags


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
- Adds a deprecation message to the repo since this has been moved to open edX plugins for a long time.

### How can this be tested?

Open the readme on this branch and see of everything looks fine, the readme parsing & display is intact

